### PR TITLE
Fix: bump version to 0.1.5 to fix failed PyPI publish

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "keboola_streamlit"
-version = "v0.1.3"
+version = "v0.1.5"
 dependencies = [
     "streamlit>=1.37.0",
     "pandas",


### PR DESCRIPTION
Version 0.1.3 was already published on PyPI, causing the CI publish job to fail with 400 File already exists. Tag v0.1.4 was created in git but pyproject.toml was never updated, so the build produced 0.1.3 again. This PR bumps the version to 0.1.5 (skipping 0.1.4) to recover and successfully publish to PyPI.