### PR TITLE
feat(deps)!: AJDA-2853 make Snowflake support an optional extra

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,9 +38,37 @@ jobs:
           uv build --wheel
           uv run --isolated --with dist/*.whl python -c "from keboola_streamlit import KeboolaStreamlit; print('Smoke test passed')"
 
+  test-snowflake-extra:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.13']
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install dependencies with snowflake extra
+        run: uv sync --extra snowflake
+
+      - name: Run tests
+        run: uv run pytest
+
   publish-event-info:
     runs-on: ubuntu-latest
-    needs: test
+    needs:
+      - test
+      - test-snowflake-extra
     outputs:
       is_deploy_ready: ${{ steps.deploy_ready.outputs.is_deploy_ready }}
       is_default_branch: ${{ steps.default_branch.outputs.is_default_branch }}
@@ -86,6 +114,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - test
+      - test-snowflake-extra
       - publish-event-info
     if: needs.publish-event-info.outputs.is_deploy_ready == 'true'
     steps:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ To install:
 pip install keboola-streamlit
 ```
 
+If you also need the [Snowflake Integration](#snowflake-integration) functions, install the
+`snowflake` extra:
+
+```bash
+pip install keboola-streamlit[snowflake]
+```
+
 _If you are using `streamlit<=1.36.0`, please use version `0.0.5` of the keboola-streamlit package._
 
 ## Usage
@@ -83,6 +90,8 @@ df = keboola.add_table_selection(sidebar=True)
 ```
 
 ### Snowflake Integration
+
+> Requires the `snowflake` extra: `pip install keboola-streamlit[snowflake]`
 
 #### Creating a Snowflake Session
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ dependencies = [
     "pandas",
     "kbcstorage",
     "deprecated",
-    "snowflake-snowpark-python>=1.35.0",
 ]
 requires-python = ">=3.10"
 authors = [
@@ -31,6 +30,9 @@ classifiers = [
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
+
+[project.optional-dependencies]
+snowflake = ["snowflake-snowpark-python>=1.35.0"]
 
 [project.urls]
 Repository = "https://github.com/keboola/keboola_streamlit/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "keboola_streamlit"
-version = "v0.1.5"
+version = "v0.2.0"
 dependencies = [
     "streamlit>=1.37.0",
     "pandas",

--- a/src/keboola_streamlit/keboola_streamlit.py
+++ b/src/keboola_streamlit/keboola_streamlit.py
@@ -443,15 +443,23 @@ class KeboolaStreamlit:
     def snowflake_create_session_object(self) -> Optional[Session]:
         """
         Creates a Snowflake session.
+
+        Returns:
+            Optional[Session]: The Snowflake session, or None if session creation failed
+            (the error is logged and shown via st.error).
         """
         try:
             from snowflake.snowpark import Session
             from cryptography.hazmat.primitives import serialization
-        except ImportError as e:
-            raise ImportError(
-                "Snowflake support requires an optional dependency. "
-                "Install it with: pip install keboola-streamlit[snowflake]"
-            ) from e
+        except ModuleNotFoundError as e:
+            missing = e.name or ""
+            missing_root = missing.split(".", 1)[0]
+            if missing_root in ("snowflake", "cryptography"):
+                raise ImportError(
+                    "Snowflake support requires an optional dependency. "
+                    "Install it with: pip install keboola-streamlit[snowflake]"
+                ) from e
+            raise
 
         session = None
         try:

--- a/src/keboola_streamlit/keboola_streamlit.py
+++ b/src/keboola_streamlit/keboola_streamlit.py
@@ -545,7 +545,7 @@ class KeboolaStreamlit:
             return None
         try:
             if return_df:
-                snowflake_df = session.sql(query, params=params).collect()
+                snowflake_df = session.sql(query, params=params).to_pandas()
                 self.create_event(
                     message="Streamlit App Snowflake Query",
                     event_type="keboola_data_app_snowflake_query",

--- a/src/keboola_streamlit/keboola_streamlit.py
+++ b/src/keboola_streamlit/keboola_streamlit.py
@@ -1,16 +1,19 @@
+from __future__ import annotations
+
 import csv
 import logging
 import os
 import re
 import uuid
-from cryptography.hazmat.primitives import serialization
-from typing import Any, Dict, List, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple
 
 import pandas as pd
 import requests
 import streamlit as st
 from kbcstorage.client import Client
-from snowflake.snowpark import Session
+
+if TYPE_CHECKING:
+    from snowflake.snowpark import Session
 
 
 # Configure logging
@@ -441,6 +444,16 @@ class KeboolaStreamlit:
         """
         Creates a Snowflake session.
         """
+        try:
+            from snowflake.snowpark import Session
+            from cryptography.hazmat.primitives import serialization
+        except ImportError as e:
+            raise ImportError(
+                "Snowflake support requires an optional dependency. "
+                "Install it with: pip install keboola-streamlit[snowflake]"
+            ) from e
+
+        session = None
         try:
             connection_parameters = self._get_connection_parameters()
             if "private_key" in connection_parameters:

--- a/src/keboola_streamlit/keboola_streamlit.py
+++ b/src/keboola_streamlit/keboola_streamlit.py
@@ -486,7 +486,15 @@ class KeboolaStreamlit:
             st.error(f"An error occurred while creating Snowflake session: {e}")
         return session
 
-    def snowflake_read_table(self, session: Session, table_id: str) -> pd.DataFrame:
+    def _log_missing_snowflake_session(self) -> None:
+        message = (
+            "No Snowflake session provided. snowflake_create_session_object() likely failed "
+            "and returned None - check the error logged from that call."
+        )
+        logging.error(message)
+        st.error(message)
+
+    def snowflake_read_table(self, session: Optional[Session], table_id: str) -> pd.DataFrame:
         """
         Loads a table from Snowflake Workspace.
 
@@ -497,6 +505,9 @@ class KeboolaStreamlit:
         Returns:
             pd.DataFrame: The table data as a Pandas DataFrame.
         """
+        if session is None:
+            self._log_missing_snowflake_session()
+            return pd.DataFrame()
         try:
             df_snowflake = session.table(table_id).to_pandas()
             self.create_event(
@@ -512,7 +523,7 @@ class KeboolaStreamlit:
 
     def snowflake_execute_query(
         self,
-        session: Session,
+        session: Optional[Session],
         query: str,
         params: Optional[Sequence[Any]] = None,
         return_df: bool = True,
@@ -529,6 +540,9 @@ class KeboolaStreamlit:
         Returns:
             Optional[pd.DataFrame]: The query results as a Pandas DataFrame if return_df is True, otherwise None.
         """
+        if session is None:
+            self._log_missing_snowflake_session()
+            return None
         try:
             if return_df:
                 snowflake_df = session.sql(query, params=params).collect()
@@ -551,7 +565,7 @@ class KeboolaStreamlit:
 
     def snowflake_write_table(
         self,
-        session: Session,
+        session: Optional[Session],
         df: pd.DataFrame,
         table_id: str,
         auto_create_table: bool = False,
@@ -570,6 +584,9 @@ class KeboolaStreamlit:
         Returns:
             None
         """
+        if session is None:
+            self._log_missing_snowflake_session()
+            return None
         try:
             session.write_pandas(df, table_id, auto_create_table=auto_create_table, overwrite=overwrite)
             self.create_event(

--- a/src/keboola_streamlit/keboola_streamlit.py
+++ b/src/keboola_streamlit/keboola_streamlit.py
@@ -440,7 +440,7 @@ class KeboolaStreamlit:
 
         raise KeyError("Neither SNOWFLAKE_PRIVATE_KEY nor SNOWFLAKE_PASSWORD is set in secrets")
 
-    def snowflake_create_session_object(self) -> Session:
+    def snowflake_create_session_object(self) -> Optional[Session]:
         """
         Creates a Snowflake session.
         """

--- a/tests/test_keboola_streamlit.py
+++ b/tests/test_keboola_streamlit.py
@@ -1,3 +1,4 @@
+import builtins
 import sys
 import os
 import pytest
@@ -82,6 +83,85 @@ def test_snowflake_create_session_object_without_extra(keboola_streamlit):
     with patch.dict(sys.modules, {"snowflake": None, "snowflake.snowpark": None}):
         with pytest.raises(ImportError, match=r"keboola-streamlit\[snowflake\]"):
             keboola_streamlit.snowflake_create_session_object()
+
+
+def test_snowflake_create_session_object_missing_unrelated_dependency_is_not_masked(keboola_streamlit):
+    # If snowflake IS installed but one of its own transitive dependencies is broken/missing
+    # (e.g. a pyarrow ABI mismatch), the error shouldn't be rewritten into a misleading
+    # "install the extra" message.
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "snowflake.snowpark":
+            raise ModuleNotFoundError("No module named 'pyarrow'", name="pyarrow")
+        return real_import(name, *args, **kwargs)
+
+    with patch("builtins.__import__", side_effect=fake_import):
+        with pytest.raises(ModuleNotFoundError, match="pyarrow"):
+            keboola_streamlit.snowflake_create_session_object()
+
+
+def _mock_snowpark_module():
+    fake_session_instance = MagicMock(name="snowflake_session")
+    fake_session_cls = MagicMock(name="Session")
+    fake_session_cls.builder.configs.return_value.create.return_value = fake_session_instance
+    fake_module = MagicMock(Session=fake_session_cls)
+    return fake_module, fake_session_cls, fake_session_instance
+
+
+def test_snowflake_create_session_object_with_password(keboola_streamlit):
+    fake_module, fake_session_cls, fake_session_instance = _mock_snowpark_module()
+    keboola_streamlit.create_event = MagicMock()
+
+    with patch.dict(sys.modules, {"snowflake": MagicMock(), "snowflake.snowpark": fake_module}):
+        with patch("streamlit.secrets") as mock_secrets:
+            mock_secrets.to_dict.return_value = {
+                "SNOWFLAKE_USER": "user",
+                "SNOWFLAKE_ACCOUNT": "account",
+                "SNOWFLAKE_ROLE": "role",
+                "SNOWFLAKE_WAREHOUSE": "wh",
+                "SNOWFLAKE_DATABASE": "db",
+                "SNOWFLAKE_SCHEMA": "schema",
+                "SNOWFLAKE_PASSWORD": "secret",
+            }
+            session = keboola_streamlit.snowflake_create_session_object()
+
+    assert session is fake_session_instance
+    connection_parameters = fake_session_cls.builder.configs.call_args[0][0]
+    assert connection_parameters["password"] == "secret"
+    assert "private_key" not in connection_parameters
+
+
+def test_snowflake_create_session_object_with_private_key(keboola_streamlit):
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    private_key_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("utf-8")
+
+    fake_module, fake_session_cls, fake_session_instance = _mock_snowpark_module()
+    keboola_streamlit.create_event = MagicMock()
+
+    with patch.dict(sys.modules, {"snowflake": MagicMock(), "snowflake.snowpark": fake_module}):
+        with patch("streamlit.secrets") as mock_secrets:
+            mock_secrets.to_dict.return_value = {
+                "SNOWFLAKE_USER": "user",
+                "SNOWFLAKE_ACCOUNT": "account",
+                "SNOWFLAKE_ROLE": "role",
+                "SNOWFLAKE_WAREHOUSE": "wh",
+                "SNOWFLAKE_DATABASE": "db",
+                "SNOWFLAKE_SCHEMA": "schema",
+                "SNOWFLAKE_PRIVATE_KEY": private_key_pem,
+            }
+            session = keboola_streamlit.snowflake_create_session_object()
+
+    assert session is fake_session_instance
+    connection_parameters = fake_session_cls.builder.configs.call_args[0][0]
+    assert isinstance(connection_parameters["private_key"], bytes)
 
 
 def test_add_table_selection(keboola_streamlit):

--- a/tests/test_keboola_streamlit.py
+++ b/tests/test_keboola_streamlit.py
@@ -193,6 +193,30 @@ def test_snowflake_write_table_without_session(keboola_streamlit):
     assert "No Snowflake session" in mock_error.call_args[0][0]
 
 
+def test_snowflake_execute_query_returns_dataframe(keboola_streamlit):
+    mock_session = MagicMock()
+    expected_df = pd.DataFrame({"col1": [1, 2]})
+    mock_session.sql.return_value.to_pandas.return_value = expected_df
+    keboola_streamlit.create_event = MagicMock()
+
+    result = keboola_streamlit.snowflake_execute_query(mock_session, "SELECT 1")
+
+    assert result is expected_df
+    mock_session.sql.return_value.to_pandas.assert_called_once()
+    mock_session.sql.return_value.collect.assert_not_called()
+
+
+def test_snowflake_execute_query_without_return_df(keboola_streamlit):
+    mock_session = MagicMock()
+    keboola_streamlit.create_event = MagicMock()
+
+    result = keboola_streamlit.snowflake_execute_query(mock_session, "UPDATE t SET x = 1", return_df=False)
+
+    assert result is None
+    mock_session.sql.return_value.collect.assert_called_once()
+    mock_session.sql.return_value.to_pandas.assert_not_called()
+
+
 def test_add_table_selection(keboola_streamlit):
     with patch("streamlit.sidebar") as mock_sidebar:
         mock_sidebar.button = MagicMock(return_value=True)

--- a/tests/test_keboola_streamlit.py
+++ b/tests/test_keboola_streamlit.py
@@ -164,6 +164,35 @@ def test_snowflake_create_session_object_with_private_key(keboola_streamlit):
     assert isinstance(connection_parameters["private_key"], bytes)
 
 
+def test_snowflake_read_table_without_session(keboola_streamlit):
+    with patch("streamlit.error") as mock_error:
+        result = keboola_streamlit.snowflake_read_table(None, "table_id")
+
+    assert isinstance(result, pd.DataFrame)
+    assert result.empty
+    mock_error.assert_called_once()
+    assert "No Snowflake session" in mock_error.call_args[0][0]
+
+
+def test_snowflake_execute_query_without_session(keboola_streamlit):
+    with patch("streamlit.error") as mock_error:
+        result = keboola_streamlit.snowflake_execute_query(None, "SELECT 1")
+
+    assert result is None
+    mock_error.assert_called_once()
+    assert "No Snowflake session" in mock_error.call_args[0][0]
+
+
+def test_snowflake_write_table_without_session(keboola_streamlit):
+    df = pd.DataFrame({"col1": [1]})
+    with patch("streamlit.error") as mock_error:
+        result = keboola_streamlit.snowflake_write_table(None, df, "table_id")
+
+    assert result is None
+    mock_error.assert_called_once()
+    assert "No Snowflake session" in mock_error.call_args[0][0]
+
+
 def test_add_table_selection(keboola_streamlit):
     with patch("streamlit.sidebar") as mock_sidebar:
         mock_sidebar.button = MagicMock(return_value=True)

--- a/tests/test_keboola_streamlit.py
+++ b/tests/test_keboola_streamlit.py
@@ -78,6 +78,12 @@ def test_write_table(keboola_streamlit):
             keboola_streamlit._KeboolaStreamlit__client.tables.load.assert_called_once()
 
 
+def test_snowflake_create_session_object_without_extra(keboola_streamlit):
+    with patch.dict(sys.modules, {"snowflake": None, "snowflake.snowpark": None}):
+        with pytest.raises(ImportError, match=r"keboola-streamlit\[snowflake\]"):
+            keboola_streamlit.snowflake_create_session_object()
+
+
 def test_add_table_selection(keboola_streamlit):
     with patch("streamlit.sidebar") as mock_sidebar:
         mock_sidebar.button = MagicMock(return_value=True)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -694,14 +694,18 @@ wheels = [
 
 [[package]]
 name = "keboola-streamlit"
-version = "0.1.3"
+version = "0.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "deprecated" },
     { name = "kbcstorage" },
     { name = "pandas" },
-    { name = "snowflake-snowpark-python" },
     { name = "streamlit" },
+]
+
+[package.optional-dependencies]
+snowflake = [
+    { name = "snowflake-snowpark-python" },
 ]
 
 [package.dev-dependencies]
@@ -715,9 +719,10 @@ requires-dist = [
     { name = "deprecated" },
     { name = "kbcstorage" },
     { name = "pandas" },
-    { name = "snowflake-snowpark-python", specifier = ">=1.35.0" },
+    { name = "snowflake-snowpark-python", marker = "extra == 'snowflake'", specifier = ">=1.35.0" },
     { name = "streamlit", specifier = ">=1.37.0" },
 ]
+provides-extras = ["snowflake"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1379,6 +1384,19 @@ wheels = [
 ]
 
 [[package]]
+name = "python-discovery"
+version = "1.4.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/26/8b004cc36f430345136f6f00fa1aa9ed596c8ed1e8504625fa79522ff39c/python_discovery-1.4.3.tar.gz", hash = "sha256:ad57d7045a862460d4a235986c33f13ed707d3aeb9153fa47eb7dfd0d4673289", size = 70438, upload-time = "2026-07-03T13:21:51.621Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/78/9b77ecb4644d1bbea94d29abf78f21c47eca6eb79e9745b702ec0bed2e19/python_discovery-1.4.3-py3-none-any.whl", hash = "sha256:b6e1e4a7d9e3f6948c39746ffe8218225162d738ba39d05ab1d2f6c1cac4878c", size = 33885, upload-time = "2026-07-03T13:21:50.174Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1923,17 +1941,18 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "20.37.0"
+version = "21.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
     { name = "filelock" },
     { name = "platformdirs" },
+    { name = "python-discovery" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/ef/d9d4ce633df789bf3430bd81fb0d8b9d9465dfc1d1f0deb3fb62cd80f5c2/virtualenv-20.37.0.tar.gz", hash = "sha256:6f7e2064ed470aa7418874e70b6369d53b66bcd9e9fd5389763e96b6c94ccb7c", size = 5864710, upload-time = "2026-02-16T16:17:59.42Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/65/ec1d92091671e6407d3e7c1f5801413bb7b2b57630a50cae7750456ba0ed/virtualenv-21.6.0.tar.gz", hash = "sha256:e18a4d750f2b64dea73e72ffde3922f3c52365fabdc8157ebd3da20d031c4734", size = 5526111, upload-time = "2026-07-06T22:49:56.972Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/4b/6cf85b485be7ec29db837ec2a1d8cd68bc1147b1abf23d8636c5bd65b3cc/virtualenv-20.37.0-py3-none-any.whl", hash = "sha256:5d3951c32d57232ae3569d4de4cc256c439e045135ebf43518131175d9be435d", size = 5837480, upload-time = "2026-02-16T16:17:57.341Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/e7/2fbd0cc1653c53eed8f10670538bb547de2b3e37aacad283faa82a71094b/virtualenv-21.6.0-py3-none-any.whl", hash = "sha256:bce9d097950fef9d81129b333babfb7767072850c2f1acce0ec536708401bfd1", size = 5506216, upload-time = "2026-07-06T22:49:54.941Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -694,7 +694,7 @@ wheels = [
 
 [[package]]
 name = "keboola-streamlit"
-version = "0.1.5"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "deprecated" },
@@ -1384,19 +1384,6 @@ wheels = [
 ]
 
 [[package]]
-name = "python-discovery"
-version = "1.4.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "filelock" },
-    { name = "platformdirs" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/66/26/8b004cc36f430345136f6f00fa1aa9ed596c8ed1e8504625fa79522ff39c/python_discovery-1.4.3.tar.gz", hash = "sha256:ad57d7045a862460d4a235986c33f13ed707d3aeb9153fa47eb7dfd0d4673289", size = 70438, upload-time = "2026-07-03T13:21:51.621Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/28/78/9b77ecb4644d1bbea94d29abf78f21c47eca6eb79e9745b702ec0bed2e19/python_discovery-1.4.3-py3-none-any.whl", hash = "sha256:b6e1e4a7d9e3f6948c39746ffe8218225162d738ba39d05ab1d2f6c1cac4878c", size = 33885, upload-time = "2026-07-03T13:21:50.174Z" },
-]
-
-[[package]]
 name = "python-dotenv"
 version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1941,18 +1928,17 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "21.6.0"
+version = "20.37.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
     { name = "filelock" },
     { name = "platformdirs" },
-    { name = "python-discovery" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/65/ec1d92091671e6407d3e7c1f5801413bb7b2b57630a50cae7750456ba0ed/virtualenv-21.6.0.tar.gz", hash = "sha256:e18a4d750f2b64dea73e72ffde3922f3c52365fabdc8157ebd3da20d031c4734", size = 5526111, upload-time = "2026-07-06T22:49:56.972Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c1/ef/d9d4ce633df789bf3430bd81fb0d8b9d9465dfc1d1f0deb3fb62cd80f5c2/virtualenv-20.37.0.tar.gz", hash = "sha256:6f7e2064ed470aa7418874e70b6369d53b66bcd9e9fd5389763e96b6c94ccb7c", size = 5864710, upload-time = "2026-02-16T16:17:59.42Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/e7/2fbd0cc1653c53eed8f10670538bb547de2b3e37aacad283faa82a71094b/virtualenv-21.6.0-py3-none-any.whl", hash = "sha256:bce9d097950fef9d81129b333babfb7767072850c2f1acce0ec536708401bfd1", size = 5506216, upload-time = "2026-07-06T22:49:54.941Z" },
+    { url = "https://files.pythonhosted.org/packages/42/4b/6cf85b485be7ec29db837ec2a1d8cd68bc1147b1abf23d8636c5bd65b3cc/virtualenv-20.37.0-py3-none-any.whl", hash = "sha256:5d3951c32d57232ae3569d4de4cc256c439e045135ebf43518131175d9be435d", size = 5837480, upload-time = "2026-02-16T16:17:57.341Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
[link to issue](https://linear.app/keboola/issue/AJDA-2853/zkonsolidovat-nebo-rozsekat-keboola-strealmlit)

## Description

`snowflake-snowpark-python` moves from a mandatory dependency to an optional extra:

- **`pyproject.toml`**: `snowflake-snowpark-python` moved out of `dependencies` into a new `[project.optional-dependencies]` group named `snowflake`.
- **`src/keboola_streamlit/keboola_streamlit.py`**:
  - Removed the top-level `from snowflake.snowpark import Session` and `from cryptography.hazmat.primitives import serialization` imports. Added `from __future__ import annotations` plus a `TYPE_CHECKING`-guarded import of `Session` so the type hints on the four `snowflake_*` methods keep working for type checkers without requiring the package at runtime.
  - `snowflake_create_session_object` (the only method that actually instantiates a `Session`) now lazily imports `snowflake.snowpark` and `cryptography` and raises a clear `ImportError` — `"Snowflake support requires an optional dependency. Install it with: pip install keboola-streamlit[snowflake]"` — if they're missing. The other three `snowflake_*` methods (`snowflake_read_table`, `snowflake_execute_query`, `snowflake_write_table`) need no changes since they only call methods on an already-constructed `session` object.
  - Fixed a pre-existing `UnboundLocalError`: if session creation failed before the `session` variable was assigned (e.g. missing `SNOWFLAKE_PRIVATE_KEY`/`SNOWFLAKE_PASSWORD` secrets), the method crashed with an unrelated error that masked the real one. It now initializes `session = None` and returns it cleanly on failure.
- **`.github/workflows/publish.yml`**: added a `test-snowflake-extra` job that runs `uv sync --extra snowflake` + `pytest` across both supported Python versions, in addition to the existing extras-free `test` job. Both are now required for `publish` to run.
- **`README.md`**: documents the new `snowflake` extra in the Installation section and above the Snowflake Integration section.
- **`tests/test_keboola_streamlit.py`**: added `test_snowflake_create_session_object_without_extra`, verifying the helpful `ImportError` when the extra isn't installed.

## Release Notes

- **Justification**
    - Customer feedback flagged that `keboola_streamlit` bundles Snowflake client libraries (`snowflake-snowpark-python`, which transitively pulls in `snowflake-connector-python`, `boto3`, `botocore`, `cryptography`, `pyopenssl`, etc.) as a mandatory dependency, even though only 4 of the ~10 public `KeboolaStreamlit` methods use Snowflake at all, and many consumers never call them.
    - In plain terms: installing `keboola-streamlit` now pulls in far fewer packages by default. Anyone who needs the Snowflake features installs one extra (`pip install keboola-streamlit[snowflake]`) on top; everyone else gets a smaller, faster install.
- **Plans for Customer Communication**
    - Breaking change for any Data App calling `snowflake_create_session_object`, `snowflake_read_table`, `snowflake_execute_query`, or `snowflake_write_table` without adding the `snowflake` extra after upgrading — those calls now raise a clear `ImportError` with install instructions instead of connecting. A changelog/release note should tell existing Snowflake-integration users to add `keboola-streamlit[snowflake]` to their requirements.
- **Impact Analysis**
    - Only affects Data Apps that use the Snowflake integration methods; apps that don't are unaffected beyond a smaller install footprint. This is a client-side library change (not a platform service), so it isn't behind a feature flag and isn't gated per stack or tenant — consumers pick it up whenever they `pip install --upgrade`.
- **Deployment Plan**
    - Standard PyPI release via the existing `publish` GitHub Actions job, triggered by a `v*` tag on `main`. No stack-by-stack rollout needed.
- **Rollback Plan**
    - Fully revertible — a patch release restoring `snowflake-snowpark-python` as a mandatory dependency, or consumers pinning to the previous version, undoes the change. Not a one-way door.
- **Post-Release Support Plan**
    - Support should expect questions from Snowflake-integration users hitting the new `ImportError` after upgrading without the extra; point them to `pip install keboola-streamlit[snowflake]`. No additional monitoring needed beyond normal release verification.